### PR TITLE
for owner Vaud Cantonal Archives we need to encode original id

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -76,7 +76,7 @@ export default {
       const location = window.location.pathname;
       const pathArray = location.split('/');
       const owner_id_slug = pathArray[3];
-      const original_id = pathArray[5];
+      const original_id = decodeURIComponent(pathArray[5]);
 
       return {
         owner_id_slug,


### PR DESCRIPTION
Example id:
"original_id": "PP 961/7589",
"original_id": "PP 961/2271",

when calling the iframe URL we can use encodeURIComponent:
https://smapshot-beta.heig-vd.ch/embed/owner/${slug}/original_image/${encodeURIComponent(originalId)}`;